### PR TITLE
Updates to Oauth models and store:

### DIFF
--- a/baph/auth/models.py
+++ b/baph/auth/models.py
@@ -436,10 +436,13 @@ class OAuthConsumer(Base):
 
 class OAuthNonce(Base):
     __tablename__ = 'auth_oauth_nonce'
+    __table_args__ = (
+        UniqueConstraint('consumer_key', 'key', 'timestamp',
+            name='uix_consumer_nonce_timestamp'),
+    )
     id = Column(Integer, primary_key=True)
-    timestamp = Column(DateTime, nullable=False, index=True,
-        default=datetime.now)
+    timestamp = Column(DateTime, nullable=False, index=True)
     token_key = Column(String(32))
-    consumer_key = Column(String(MAX_KEY_LEN))
-    key = Column(String(255), nullable=False, unique=True)
+    consumer_key = Column(String(MAX_KEY_LEN), nullable=False)
+    key = Column(String(255), nullable=False)
 

--- a/baph/contrib/oauth/store.py
+++ b/baph/contrib/oauth/store.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf import settings
 from oauth_provider.store import InvalidConsumerError, InvalidTokenError, Store
 from sqlalchemy import or_
@@ -47,10 +49,14 @@ class ModelStore(Store):
                 - timestamp > NONCE_VALID_PERIOD:
             return False
 
+        timestamp = datetime.fromtimestamp(timestamp) \
+                            .strftime('%Y-%m-%d %H:%M:%S')
+
         session = orm.sessionmaker()
         params = {
             'consumer_key': oauth_request['oauth_consumer_key'],
             'key': oauth_request['oauth_nonce'],
+            'timestamp': timestamp,
             }
         nonce = session.query(OAuthNonce).filter_by(**params).first()
         if nonce:

--- a/baph/db/models/base.py
+++ b/baph/db/models/base.py
@@ -252,9 +252,14 @@ def generate_table_args(table_args):
       kwargs.update(table_args[-1])
     else:
       args = table_args
-  if kwargs:
-    args += (kwargs,)
-  return args
+  if args and kwargs:
+    return args + (kwargs,)
+  elif args:
+    return args
+  elif kwargs:
+    return kwargs
+  else:
+    return None
 
 class ModelBase(type):
 
@@ -343,6 +348,7 @@ class ModelBase(type):
         if attrs.get('__tablename__', None):
           table_args = attrs.pop('__table_args__', None)
           attrs['__table_args__'] = generate_table_args(table_args)
+          print 'table args:', attrs['__table_args__']
 
         # Add all attributes to the class.
         for obj_name, obj in attrs.items():

--- a/baph/db/models/base.py
+++ b/baph/db/models/base.py
@@ -348,7 +348,6 @@ class ModelBase(type):
         if attrs.get('__tablename__', None):
           table_args = attrs.pop('__table_args__', None)
           attrs['__table_args__'] = generate_table_args(table_args)
-          print 'table args:', attrs['__table_args__']
 
         # Add all attributes to the class.
         for obj_name, obj in attrs.items():

--- a/baph/test/testcases.py
+++ b/baph/test/testcases.py
@@ -372,7 +372,7 @@ class MemcacheMixin(object):
 
     def assertCacheKeyNotInvalidated(self, key, version=None):
         raw_key = self.cache.make_key(key, version=version)
-        current_value = self.cache.get(key, version=verision)
+        current_value = self.cache.get(key, version=version)
         self.assertIn(raw_key, self.initial_cache)
         self.assertNotEqual(current_value, None)
 

--- a/baph/test/testcases.py
+++ b/baph/test/testcases.py
@@ -334,8 +334,8 @@ class MemcacheMixin(object):
         reads the current key/value pairs from the cache and
         stores it in self.initial_data, for comparison with post-test results
         """
-        self.initial_cache = dict((k, self.cache.get(k)) \
-            for k in self.cache.get_all_keys())
+        self.initial_cache = {k: self.cache._cache.get(k)
+            for k in self.cache.get_all_keys()}
 
     def assertCacheHit(self, rsp):
         self.assertEqual(rsp['x-from-cache'], 'True')
@@ -344,7 +344,8 @@ class MemcacheMixin(object):
         self.assertEqual(rsp['x-from-cache'], 'False')
 
     def assertCacheKeyEqual(self, key, value, version=None):
-        self.assertEqual(self.cache.get(key, version=version), value)
+        current_value = self.cache.get(key, version=version)
+        self.assertEqual(current_value, value)
 
     def assertCacheKeyCreated(self, key, version=None):
         raw_key = self.cache.make_key(key, version=version)
@@ -353,25 +354,27 @@ class MemcacheMixin(object):
 
     def assertCacheKeyIncremented(self, key, version=None):
         raw_key = self.cache.make_key(key, version=version)
-        old = self.initial_cache.get(raw_key, 0)
-        new = self.cache.get(key)
-        self.assertEqual(new, old+1)
+        initial_value = self.initial_cache.get(raw_key, 0)
+        current_value = self.cache.get(key, version=version)
+        self.assertEqual(current_value, initial_value+1)
 
     def assertCacheKeyIncrementedMulti(self, key, version=None):
         raw_key = self.cache.make_key(key, version=version)
-        old = self.initial_cache[raw_key]
-        new = self.cache.get(key)
-        self.assertTrue(new > old)
+        initial_value = self.initial_cache[raw_key]
+        current_value = self.cache.get(key, version=version)
+        self.assertGreater(current_value, initial_value)
         
     def assertCacheKeyInvalidated(self, key, version=None):
         raw_key = self.cache.make_key(key, version=version)
+        current_value = self.cache.get(key, version=version)
         self.assertIn(raw_key, self.initial_cache)
-        self.assertEqual(self.cache.get(key), None)
+        self.assertEqual(current_value, None)
 
     def assertCacheKeyNotInvalidated(self, key, version=None):
         raw_key = self.cache.make_key(key, version=version)
+        current_value = self.cache.get(key, version=verision)
         self.assertIn(raw_key, self.initial_cache)
-        self.assertNotEqual(self.cache.get(key), None)
+        self.assertNotEqual(current_value, None)
 
 class TestCase(BaphFixtureMixin, test.TestCase):
     pass


### PR DESCRIPTION
unique nonce key is now (consumer_key, key, timestamp) instead of just the key

the timestamp that gets written into the nonce table is now the ts from the oauth request, rather than being autogenerated